### PR TITLE
Version update & removing version parameter from BaseSchema

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -41,7 +41,6 @@ async def main():
         print()
         print("Example 3: getRoute()")
         payload = {
-            "version": 37,
             "language": "de",
             "start": {
                 "name": "Ritterstraße",
@@ -158,11 +157,10 @@ async def main():
         }
         indRoute = await gti.getIndividualRoute(payload)
         print(indRoute)
-
+        
         print()
         print("Example 11: getVehicleMap()")
         payload = {
-            "version": 37,
             "boundingBox": {
                 "lowerLeft": {"x": 9.985707, "y": 53.573138, "type": "EPSG_4326"},
                 "upperRight": {"x": 9.992702, "y": 53.576916, "type": "EPSG_4326"},
@@ -180,7 +178,6 @@ async def main():
         print()
         print("Example 12: getTrackCoordinates()")
         payload = {
-            "version": 37,
             "coordinateType": "EPSG_4326",
             "stopPointKeys": [
                 "ZVU-DB:8004248:2",
@@ -203,7 +200,7 @@ async def main():
             {"station": {"name": "Wartenau", "id": "Master:10901", "type": "STATION"}}
         )
         print(si)
-
+        
         print()
         print("Example 15: tariffZoneNeighbours()")
         tzn = await gti.tariffZoneNeighbours({})

--- a/examples.py
+++ b/examples.py
@@ -157,7 +157,7 @@ async def main():
         }
         indRoute = await gti.getIndividualRoute(payload)
         print(indRoute)
-        
+
         print()
         print("Example 11: getVehicleMap()")
         payload = {
@@ -200,7 +200,7 @@ async def main():
             {"station": {"name": "Wartenau", "id": "Master:10901", "type": "STATION"}}
         )
         print(si)
-        
+
         print()
         print("Example 15: tariffZoneNeighbours()")
         tzn = await gti.tariffZoneNeighbours({})

--- a/pygti/auth.py
+++ b/pygti/auth.py
@@ -37,7 +37,7 @@ class Auth:
         else:
             headers = dict(headers)
 
-        payload.update({"version": 37})
+        payload.update({"version": 38})
 
         data = json.dumps(payload).encode("UTF-8")
 

--- a/pygti/schemas.py
+++ b/pygti/schemas.py
@@ -32,9 +32,7 @@ def DateTime(dt):
 
 
 # See 1.4 in gti docs
-BaseRequestType = Schema(
-    {"language": Language, "version": int, "filterType": FilterType}
-)
+BaseRequestType = Schema({"language": Language, "filterType": FilterType})
 
 FilterServiceType = In(
     [


### PR DESCRIPTION
updated the api version to 38
Removed the version parameter from the BaseSchema to prevent the user from using it (because it will be overriden in auth.py either way)