### PR TITLE
changed isort cfg to cooperate with black

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -4,8 +4,7 @@ from datetime import datetime, timedelta
 
 import aiohttp
 from pygti.auth import Auth
-from pygti.const import *
-from pygti.gti import *
+from pygti.gti import GTI
 
 try:
     from dotenv import load_dotenv

--- a/pygti/gti.py
+++ b/pygti/gti.py
@@ -1,6 +1,21 @@
 from .auth import Auth
 from .const import *
-from .schemas import *
+from .schemas import (
+    AnnouncementRequest,
+    CNRequest,
+    DLRequest,
+    GRRequest,
+    IndividualRouteRequest,
+    LLRequest,
+    LSRequest,
+    PostalCodeRequest,
+    SIRequest,
+    TariffRequest,
+    TariffZoneNeighboursRequest,
+    TLRequest,
+    TrackCoordinatesRequest,
+    VehicleMapRequest,
+)
 
 
 class GTI:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [isort]
 known_first_party = pygti
+multi_line_output=3
+include_trailing_comma=true
+line_length=88


### PR DESCRIPTION
changed some imports to be more specific. While doing this I discovered that isort and black are conflicting in the way of handling long import statements. I changed the isort config to work with black.

I am not sure if azure-pipeline is using the setup.cfg as well. If not they will complain about the formatting.