### PR TITLE
updated setup.py and __init__.py

### DIFF
--- a/pygti/__init__.py
+++ b/pygti/__init__.py
@@ -1,0 +1,1 @@
+from pygti.gti import GTI

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ REQUIRES_PYTHON = ">=3.6.0"
 VERSION = "0.7.0"
 
 # What packages are required for this module to be executed?
-REQUIRED = ["requests", "voluptuous"]
+REQUIRED = ["aiohttp", "voluptuous"]
 
 # What packages are optional?
 EXTRAS = {
@@ -102,11 +102,7 @@ setup(
     python_requires=REQUIRES_PYTHON,
     url=URL,
     packages=find_packages(exclude=["tests", "*.tests", "*.tests.*", "tests.*"]),
-    entry_points={
-        "console_scripts": [
-            "stadtreinigung_hamburg = stadtreinigung_hamburg.stadtreinigung_hamburg:main"
-        ]
-    },
+    entry_points={},
     install_requires=REQUIRED,
     extras_require=EXTRAS,
     include_package_data=True,


### PR DESCRIPTION
changed the "requests" module to the "aiohttp" module as required module. requests isn't used anymore or am i missing something?

added the GTI class to the __init__.py file. That should remove the other modules (schema, auth and so on) from being open to use, which brings some clarity in how to use the module. I am not quite sure if thats the right approach, i was following this guide (https://medium.com/@joel.barmettler/how-to-upload-your-python-package-to-pypi-65edc5fe9c56 -see: `Create a python package`)


removed some old code from the setup.py

is there a possibility to check this changes locally so i can test it properly before sending you iterations of pr's?

