### PR TITLE
added workaround for error of aiohttp in python38

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import sys
 from datetime import datetime, timedelta
 
 import aiohttp
@@ -214,4 +215,15 @@ async def main():
         print(tl)
 
 
+# To avoid 'Event loop is closed' RuntimeError due to compatibility issue with aiohttp
+if sys.platform.startswith("win") and sys.version_info >= (3, 8):
+    try:
+        from asyncio import WindowsSelectorEventLoopPolicy
+    except ImportError:
+        pass
+    else:
+        if not isinstance(
+            asyncio.get_event_loop_policy(), WindowsSelectorEventLoopPolicy
+        ):
+            asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
 asyncio.run(main())


### PR DESCRIPTION
see #18 .
Workaround that sets the event loop policy of aiohttp to `WindowsSelectorEvent` because python3.8 is using it. 
