### PR TITLE
changed getTrackCoordinates() example to use new(?) keys

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -181,12 +181,7 @@ async def main():
         print("Example 12: getTrackCoordinates()")
         payload = {
             "coordinateType": "EPSG_4326",
-            "stopPointKeys": [
-                "ZVU-DB:8004248:2",
-                "ZVU-DB:8004247:2",
-                "ZVU-DB:809100:1",
-                "ZVU-DB:119106:1",
-            ],
+            "stopPointKeys": ["HHA-U:909010:1", "HHA-U:119000:1"],
         }
         tc = await gti.getTrackCoordinates(payload)
         print(tc)


### PR DESCRIPTION
Seems like the coordinates used in the example aren't working anymore.

Used coordinates that were returned from the getVehicleMap() function