### PR TITLE
Add release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,44 @@
+name-template: v$RESOLVED_VERSION
+tag-template: v$RESOLVED_VERSION
+categories:
+  - title: ⚠️ Breaking Changes
+    label: breaking change
+  - title: 🚀 Features
+    label: feature
+  - title: 🐛 Bug Fixes
+    label: fix
+  - title: 🧰 Maintenance
+    label: chore
+  - title: ⬆️ Dependencies
+    label: dependencies
+  - title: 🔁 Continuous Integration
+    label: ci
+template: |
+  # Changelog
+
+  $CHANGES
+
+  ---
+
+  *Get it on PyPi:*
+  ```
+  pip install pygti==$RESOLVED_VERSION
+  ```
+
+  https://pypi.org/project/pygti/$RESOLVED_VERSION/
+
+
+version-resolver:
+  major:
+    labels:
+      - 'breaking change'
+  minor:
+    labels:
+      - 'feature'
+  patch:
+    labels:
+      - 'chore'
+      - 'dependencies'
+      - 'fix'
+      - 'ci'
+  default: patch

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+          # config-name: my-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds https://github.com/release-drafter/release-drafter.
It will create a draft release based on the PRs merged and automatically calculates the next semantic version based on the label. We can still manually alter the release, but it should make it easier for us.

Releasing a draft will automatically create a new tag, which triggers our azure pipeline, and publishes that version to PyPi