### PR TITLE
Change default host to new host

### DIFF
--- a/pygti/auth.py
+++ b/pygti/auth.py
@@ -7,7 +7,7 @@ from aiohttp import ClientConnectorError, ClientResponse, ClientSession
 
 from .exceptions import *
 
-GTI_DEFAULT_HOST = "api-prod.geofox.de"
+GTI_DEFAULT_HOST = "gti.geofox.de"
 
 
 class Auth:


### PR DESCRIPTION
I received this mail from the Geofox Team:

> Sehr geehrte Damen und Herren,
> 
> aktuell führen wir einen neuen GTI-Server ein. Wir möchten Sie bitten uns durch Nutzung des neuen Servers zu unterstützen und die Umstellung auf den neuen Server aktiv vorzunehmen.
> 
> Der neue DNS-Name des Servers lautet: gti.geofox.de.
> 
> Sollten im Probebetrieb bei Ihnen Fehler auftreten, bitten wir Sie uns diese zu melden an api@geofox.de.
> 
> Zum 01.11.2020 wird dann eine automatische Umstellung vorgenommen und der alte DNS-Server abgeschaltet.
> 
> Im Zuge der Umstellung haben wir aus Sicherheitsgründen die Unterstützung des http-Protokolls abgeschaltet und lassen nur noch https-Verbindungen zu.
> 
> Bei weiteren Fragen wenden Sie sich gerne an uns.
> 
> Mit freundlichen Grüßen

This PR changes the default host to the new dns name.