### PR TITLE
Remove stdlib from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ REQUIRES_PYTHON = ">=3.6.0"
 VERSION = "0.8.0"
 
 # What packages are required for this module to be executed?
-REQUIRED = ["aiohttp", "asyncio", "voluptuous", "pytz"]
+REQUIRED = ["aiohttp", "voluptuous", "pytz"]
 
 # What packages are optional?
 EXTRAS = {


### PR DESCRIPTION
Remove the standard library from requirements to avoid overwriting old libs which are future maintain on python. Otherwise the library can't used by Home Assistant: https://github.com/home-assistant/core/pull/41571/checks?check_run_id=1233203687#step:6:27